### PR TITLE
支持使用自定义方法解析环境变量

### DIFF
--- a/lib/ut_env_parser.ex
+++ b/lib/ut_env_parser.ex
@@ -215,6 +215,10 @@ defmodule UTEnvParser do
     raise RequiredValueError, key: key_opts.name, hint: key_opts.hint
   end
 
+  defp raise_invalid_value_error(%{type: parser} = key_opts, raw) when is_function(parser) do
+    raise InvalidValueError, type: :custom_parser, key: key_opts.name, value: raw
+  end
+
   defp raise_invalid_value_error(key_opts, raw) do
     raise InvalidValueError, type: key_opts.type, key: key_opts.name, value: raw
   end

--- a/lib/ut_env_parser/key_opts.ex
+++ b/lib/ut_env_parser/key_opts.ex
@@ -30,7 +30,15 @@ defmodule UTEnvParser.KeyOpts do
            hint: String.t() | nil
          }
 
-  @type! type :: :integer | :float | :number | :boolean | :string | {:array, :string}
+  @type! type ::
+           :integer
+           | :float
+           | :number
+           | :boolean
+           | :string
+           | {:array, :string}
+           | function()
+           | {:array, function()}
 
   @spec! new(opts :: keyword()) :: t()
   def new(opts) do
@@ -40,7 +48,7 @@ defmodule UTEnvParser.KeyOpts do
     |> add_type_specific_default_opts()
   end
 
-  defp add_type_specific_default_opts(%__MODULE__{type: {:array, :string}} = key_opts) do
+  defp add_type_specific_default_opts(%__MODULE__{type: {:array, _}} = key_opts) do
     %{key_opts | splitter: key_opts.splitter || ~r/\s*,\s*/}
   end
 

--- a/test/ut_env_parser_test.exs
+++ b/test/ut_env_parser_test.exs
@@ -440,5 +440,15 @@ defmodule UTEnvParserTest do
 
       assert config == %{key: 1}
     end
+
+    test "invalid value" do
+      assert {:error, error} =
+               UTEnvParser.parse(
+                 [key: [type: fn value -> {:ok, String.to_integer(value)} end]],
+                 get_env_fn: fn "KEY" -> "not a number" end
+               )
+
+      assert error == %InvalidValueError{type: :custom_parser, key: :key, value: "not a number"}
+    end
   end
 end


### PR DESCRIPTION
起因是为了设置 endpoint 中关于 ip 相关的配置。
简单起见，允许传入匿名方法，以满足各种需求。